### PR TITLE
[ADD] 회원 정보 반환 및 수정, 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/dalc/one/ExceptionEnum.java
+++ b/src/main/java/com/dalc/one/ExceptionEnum.java
@@ -8,12 +8,19 @@ import lombok.ToString;
 @Getter
 @ToString
 public enum ExceptionEnum {
+	//로그인
 	LOGIN_FAIL(HttpStatus.NOT_FOUND, "아이디 또는 비밀번호가 잘못 입력되었습니다."),
 	NO_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	NOT_MATCH(HttpStatus.NOT_FOUND, "로그인한 사용자의 정보와 일치하지 않습니다."),
-    RUNTIME_EXCEPTION(HttpStatus.BAD_REQUEST, "E0001"),
-    ACCESS_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "E0002"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0003");  
+	//회원가입
+	EXIST_ID(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
+	EXIST_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+	EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+	NOT_DATA_ACCESS(HttpStatus.BAD_REQUEST, "올바르지 않은 정보가 있습니다."),
+	NULL(HttpStatus.BAD_REQUEST, "입력되지 않은 정보가 있습니다."),
+	//인증
+	NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."), 
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
 
     private final HttpStatus status;
     private String message;

--- a/src/main/java/com/dalc/one/controller/IndexController.java
+++ b/src/main/java/com/dalc/one/controller/IndexController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -40,7 +41,7 @@ public class IndexController {
 
 	//adminTest
 	@ResponseBody
-	@RequestMapping("/admin/user") 
+	@GetMapping("/admin/user") 
 	public ResponseEntity<Map<String, Object>> indexData(ModelMap model) {
 		List<User> userList = lehgo.getUserList();
 		

--- a/src/main/java/com/dalc/one/dao/UserDAO.java
+++ b/src/main/java/com/dalc/one/dao/UserDAO.java
@@ -10,4 +10,10 @@ public interface UserDAO {
 	List<User> getUserList()  throws DataAccessException;
 	User findUserbyUserId(String id) throws DataAccessException;
 	void signUp(User user) throws DataAccessException;
+
+	public int checkUserId(String id) throws DataAccessException;
+	public int checkUserEmail(String email) throws DataAccessException;
+	public int checkUserNickname(String nickname) throws DataAccessException;
+	public void updateUserInfo(User user) throws DataAccessException;
+	public void deleteUser(String id) throws DataAccessException;
 }

--- a/src/main/java/com/dalc/one/dao/mybatis/MybatisUserDAO.java
+++ b/src/main/java/com/dalc/one/dao/mybatis/MybatisUserDAO.java
@@ -29,4 +29,25 @@ public class MybatisUserDAO implements UserDAO {
 	public void signUp(User user) {
 		userMapper.signUp(user);
 	}
+
+	@Override
+	public int checkUserId(String id){
+		return userMapper.checkUserId(id);
+	}
+	@Override
+	public int checkUserEmail(String email){
+		return userMapper.checkUserEmail(email);
+	}
+	@Override
+	public int checkUserNickname(String nickname){
+		return userMapper.checkUserNickname(nickname);
+	}
+	@Override
+	public void updateUserInfo(User user) {
+		userMapper.updateUserInfo(user);
+	}
+	@Override
+	public void deleteUser(String id) {
+		userMapper.deleteUser(id);
+	}
 }

--- a/src/main/java/com/dalc/one/dao/mybatis/mapper/UserMapper.java
+++ b/src/main/java/com/dalc/one/dao/mybatis/mapper/UserMapper.java
@@ -13,4 +13,10 @@ public interface UserMapper {
 	List<User> getUserList();
 	User findUserbyUserId(String id);
 	void signUp(User user);
+
+	public int checkUserId(String id);
+	public int checkUserEmail(String email);
+	public int checkUserNickname(String nickname);
+	public void updateUserInfo(User user);
+	public void deleteUser(String id);
 }

--- a/src/main/java/com/dalc/one/domain/User.java
+++ b/src/main/java/com/dalc/one/domain/User.java
@@ -6,6 +6,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 import org.springframework.context.annotation.Role;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -19,12 +23,19 @@ import lombok.Setter;
 @Setter
 @SuppressWarnings("serial")
 public class User implements Serializable {
+    @NotBlank
 	private String id;
+    @NotBlank
 	private String name;
+    @NotBlank
 	private String password;
+    @NotBlank
 	private String email;
+    @NotBlank
 	private String nickname;
+    @NotBlank
 	private String gender;
+    @NotBlank
 	private String age;
 	private String platform;
 	private String token;
@@ -36,6 +47,13 @@ public class User implements Serializable {
 		this.name = name;
 		this.password = password;
 		this.auth = auth;
+	}
+
+	@Override
+	public String toString() {
+		return "User [id=" + id + ", name=" + name + ", password=" + password + ", email=" + email + ", nickname="
+				+ nickname + ", gender=" + gender + ", age=" + age + ", platform=" + platform + ", token=" + token
+				+ ", auth=" + auth + "]";
 	}
 	/* JavaBeans Properties */
 }

--- a/src/main/resources/com/dalc/one/dao/mybatis/mapper/UserMapper.xml
+++ b/src/main/resources/com/dalc/one/dao/mybatis/mapper/UserMapper.xml
@@ -6,19 +6,48 @@
 	<cache />
 	<select id="getUserList" resultType="User">
 		SELECT *
-		FROM USERINFO
+		FROM USERINFO WHERE ACTIVE = 1
 	</select>
 	
 	<select id="findUserbyUserId" resultType="User">
 		SELECT *
 		FROM USERINFO
-		WHERE USER_ID = #{id}
+		WHERE USER_ID = #{id} AND ACTIVE = 1
 	</select>
 	
+	<select id="checkUserId" resultType="int">
+		SELECT COUNT(USER_ID)
+		FROM USERINFO
+		WHERE USER_ID = #{id}
+	</select>
+	<select id="checkUserEmail" resultType="int">
+		SELECT COUNT(USER_ID)
+		FROM USERINFO
+		WHERE EMAIL = #{email} AND ACTIVE = 1
+	</select>
+	<select id="checkUserNickname" resultType="int">
+		SELECT COUNT(USER_ID)
+		FROM USERINFO
+		WHERE NICKNAME = #{nickname} AND ACTIVE = 1
+	</select>
+	
+	<update id="updateUserInfo" parameterType="User">
+		UPDATE USERINFO
+		SET USER_NAME = #{name},
+			EMAIL = #{email},
+			NICKNAME = #{nickname},
+			AGE = #{age}
+		WHERE USER_ID = #{id}
+	</update>
 	<insert id="signUp" parameterType="User">
 		INSERT INTO USERINFO
 		(USER_ID, USER_NAME, PASSWORD, EMAIL, NICKNAME, GENDER, AGE)
 		VALUES
 		(#{id}, #{name}, #{password}, #{email}, #{nickname}, #{gender}, #{age})
 	</insert>
+	<update id="deleteUser" parameterType="String">
+		UPDATE USERINFO
+		SET ACTIVE = 0
+		WHERE USER_ID = #{id}
+	</update>
 </mapper>


### PR DESCRIPTION
**회원 정보 반환** 
`GET users/{id}`
로그인하지 않았거나, URI의 id와 로그인한 회원의 id가 일치하지 않으면 오류 발생

**회원 정보 수정** 
`POST users/{id}`
로그인하지 않았거나, URI의 id와 로그인한 회원의 id가 일치하지 않으면 오류 발생
이미 존재하는 email이나 nickname으로 수정을 요청했을 시 오류 발생

**회원 탈퇴**
`DELETE users/{id}`
로그인하지 않았거나, URI의 id와 로그인한 회원의 id가 일치하지 않으면 오류 발생
회원 정보를 삭제(DELETE)하지 않고 회원의 'ACTIVE'를 0으로 변경
-> 
ACTIVE가 0인 회원인 경우 로그인할 수 없으며
회원 목록 반환 / 이메일 및 닉네임 중복체크 대상에서 제외됨